### PR TITLE
Remove all the Sync and Send trait bounds

### DIFF
--- a/iota-streams-app-channels/src/api/key_store.rs
+++ b/iota-streams-app-channels/src/api/key_store.rs
@@ -14,7 +14,7 @@ use iota_streams_core::{
 };
 use iota_streams_core_edsig::key_exchange::x25519;
 
-pub trait KeyStore<Info, F: PRP>: Default + Send + Sync {
+pub trait KeyStore<Info, F: PRP>: Default {
     fn filter<'a, I>(&self, ids: I) -> Vec<(&Identifier, Vec<u8>)>
     where
         I: IntoIterator<Item = &'a Identifier>;
@@ -55,7 +55,7 @@ impl<Info> Default for KeyMap<Info> {
     }
 }
 
-impl<Info: Send + Sync, F: PRP> KeyStore<Info, F> for KeyMap<Info> {
+impl<Info, F: PRP> KeyStore<Info, F> for KeyMap<Info> {
     fn filter<'a, I>(&self, ids: I) -> Vec<(&Identifier, Vec<u8>)>
     where
         I: IntoIterator<Item = &'a Identifier>,

--- a/iota-streams-app-channels/src/api/user.rs
+++ b/iota-streams-app-channels/src/api/user.rs
@@ -995,7 +995,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Link, LG, LS, Keys> ContentSizeof<F> for User<F, Link, LG, LS, Keys>
 where
     F: PRP,
@@ -1054,7 +1054,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Link, Store, LG, LS, Keys> ContentWrap<F, Store> for User<F, Link, LG, LS, Keys>
 where
     F: PRP,
@@ -1118,7 +1118,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Link, Store, LG, LS, Keys> ContentUnwrap<F, Store> for User<F, Link, LG, LS, Keys>
 where
     F: PRP,

--- a/iota-streams-app-channels/src/message/announce.rs
+++ b/iota-streams-app-channels/src/message/announce.rs
@@ -55,7 +55,7 @@ impl<'a, F> ContentWrap<'a, F> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F: PRP> message::ContentSizeof<F> for ContentWrap<'a, F> {
     async fn sizeof<'c>(&self, ctx: &'c mut sizeof::Context<F>) -> Result<&'c mut sizeof::Context<F>> {
         ctx.absorb(&self.sig_kp.public)?;
@@ -65,8 +65,8 @@ impl<'a, F: PRP> message::ContentSizeof<F> for ContentWrap<'a, F> {
     }
 }
 
-#[async_trait]
-impl<'a, F: PRP, Store: Send + Sync> message::ContentWrap<F, Store> for ContentWrap<'a, F> {
+#[async_trait(?Send)]
+impl<'a, F: PRP, Store> message::ContentWrap<F, Store> for ContentWrap<'a, F> {
     async fn wrap<'c, OS: io::OStream>(
         &self,
         _store: &Store,
@@ -103,11 +103,10 @@ impl<F> Default for ContentUnwrap<F> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Store> message::ContentUnwrap<F, Store> for ContentUnwrap<F>
 where
     F: PRP,
-    Store: Send + Sync,
 {
     async fn unwrap<'c, IS: io::IStream>(
         &mut self,

--- a/iota-streams-app-channels/src/message/keyload.rs
+++ b/iota-streams-app-channels/src/message/keyload.rs
@@ -104,7 +104,7 @@ where
     pub(crate) _phantom: core::marker::PhantomData<(F, Link)>,
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link> message::ContentSizeof<F> for ContentWrap<'a, F, Link>
 where
     F: 'a + PRP, // weird 'a constraint, but compiler requires it somehow?!
@@ -149,7 +149,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link, Store> message::ContentWrap<F, Store> for ContentWrap<'a, F, Link>
 where
     F: 'a + PRP, // weird 'a constraint, but compiler requires it somehow?!
@@ -241,7 +241,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, 'b, F, Link, LStore, PskStore, KeSkStore> message::ContentUnwrap<F, LStore>
     for ContentUnwrap<'a, F, Link, PskStore, KeSkStore>
 where
@@ -249,8 +249,8 @@ where
     Link: HasLink,
     Link::Rel: Eq + Default + SkipFallback<F>,
     LStore: LinkStore<F, Link::Rel>,
-    PskStore: for<'c> Lookup<&'c Identifier, psk::Psk> + Send + Sync,
-    KeSkStore: for<'c> Lookup<&'c Identifier, &'b x25519::StaticSecret> + 'b + Send + Sync,
+    PskStore: for<'c> Lookup<&'c Identifier, psk::Psk>,
+    KeSkStore: for<'c> Lookup<&'c Identifier, &'b x25519::StaticSecret> + 'b,
 {
     async fn unwrap<'c, IS: io::IStream>(
         &mut self,

--- a/iota-streams-app-channels/src/message/sequence.rs
+++ b/iota-streams-app-channels/src/message/sequence.rs
@@ -55,7 +55,7 @@ where
     pub(crate) ref_link: &'a <Link as HasLink>::Rel,
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link> message::ContentSizeof<F> for ContentWrap<'a, Link>
 where
     F: PRP,
@@ -73,7 +73,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link, Store> message::ContentWrap<F, Store> for ContentWrap<'a, Link>
 where
     F: PRP,
@@ -117,7 +117,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Link, Store> message::ContentUnwrap<F, Store> for ContentUnwrap<Link>
 where
     F: PRP,

--- a/iota-streams-app-channels/src/message/signed_packet.rs
+++ b/iota-streams-app-channels/src/message/signed_packet.rs
@@ -61,7 +61,7 @@ where
     pub(crate) _phantom: core::marker::PhantomData<(F, Link)>,
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link> message::ContentSizeof<F> for ContentWrap<'a, F, Link>
 where
     F: PRP,
@@ -80,7 +80,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link, Store> message::ContentWrap<F, Store> for ContentWrap<'a, F, Link>
 where
     F: PRP,
@@ -126,7 +126,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Link, Store> message::ContentUnwrap<F, Store> for ContentUnwrap<F, Link>
 where
     F: PRP,

--- a/iota-streams-app-channels/src/message/subscribe.rs
+++ b/iota-streams-app-channels/src/message/subscribe.rs
@@ -74,7 +74,7 @@ pub struct ContentWrap<'a, F, Link: HasLink> {
     pub(crate) _phantom: core::marker::PhantomData<(Link, F)>,
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link> message::ContentSizeof<F> for ContentWrap<'a, F, Link>
 where
     F: PRP,
@@ -91,7 +91,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link, Store> message::ContentWrap<F, Store> for ContentWrap<'a, F, Link>
 where
     F: PRP,
@@ -140,7 +140,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link, Store> message::ContentUnwrap<F, Store> for ContentUnwrap<'a, F, Link>
 where
     F: PRP,

--- a/iota-streams-app-channels/src/message/tagged_packet.rs
+++ b/iota-streams-app-channels/src/message/tagged_packet.rs
@@ -61,7 +61,7 @@ where
     pub(crate) _phantom: core::marker::PhantomData<(F, Link)>,
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link> message::ContentSizeof<F> for ContentWrap<'a, F, Link>
 where
     F: PRP,
@@ -81,7 +81,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a, F, Link, Store> message::ContentWrap<F, Store> for ContentWrap<'a, F, Link>
 where
     F: PRP,
@@ -126,7 +126,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Link, Store> message::ContentUnwrap<F, Store> for ContentUnwrap<F, Link>
 where
     F: PRP,

--- a/iota-streams-app/src/identifier.rs
+++ b/iota-streams-app/src/identifier.rs
@@ -78,7 +78,7 @@ impl From<PskId> for Identifier {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F: PRP> ContentSizeof<F> for Identifier {
     async fn sizeof<'c>(&self, ctx: &'c mut sizeof::Context<F>) -> Result<&'c mut sizeof::Context<F>> {
         match *self {
@@ -96,8 +96,8 @@ impl<F: PRP> ContentSizeof<F> for Identifier {
     }
 }
 
-#[async_trait]
-impl<F: PRP, Store: Send + Sync> ContentWrap<F, Store> for Identifier {
+#[async_trait(?Send)]
+impl<F: PRP, Store> ContentWrap<F, Store> for Identifier {
     async fn wrap<'c, OS: io::OStream>(
         &self,
         _store: &Store,
@@ -118,8 +118,8 @@ impl<F: PRP, Store: Send + Sync> ContentWrap<F, Store> for Identifier {
     }
 }
 
-#[async_trait]
-impl<F: PRP, Store: Send + Sync> ContentUnwrap<F, Store> for Identifier {
+#[async_trait(?Send)]
+impl<F: PRP, Store> ContentUnwrap<F, Store> for Identifier {
     async fn unwrap<'c, IS: io::IStream>(
         &mut self,
         _store: &'c Store,
@@ -131,8 +131,8 @@ impl<F: PRP, Store: Send + Sync> ContentUnwrap<F, Store> for Identifier {
     }
 }
 
-#[async_trait]
-impl<F: PRP, Store: Send + Sync> ContentUnwrapNew<F, Store> for Identifier {
+#[async_trait(?Send)]
+impl<F: PRP, Store> ContentUnwrapNew<F, Store> for Identifier {
     async fn unwrap_new<'c, IS: io::IStream>(
         _store: &Store,
         ctx: &'c mut unwrap::Context<F, IS>,

--- a/iota-streams-app/src/message/content.rs
+++ b/iota-streams-app/src/message/content.rs
@@ -13,12 +13,12 @@ use iota_streams_ddml::{
     io,
 };
 
-#[async_trait]
-pub trait ContentSizeof<F>: Send + Sync {
+#[async_trait(?Send)]
+pub trait ContentSizeof<F> {
     async fn sizeof<'c>(&self, ctx: &'c mut sizeof::Context<F>) -> Result<&'c mut sizeof::Context<F>>;
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait ContentWrap<F, Store>: ContentSizeof<F> {
     async fn wrap<'c, OS: io::OStream>(
         &self,
@@ -27,8 +27,8 @@ pub trait ContentWrap<F, Store>: ContentSizeof<F> {
     ) -> Result<&'c mut wrap::Context<F, OS>>;
 }
 
-#[async_trait]
-pub trait ContentUnwrap<F, Store>: Send + Sync {
+#[async_trait(?Send)]
+pub trait ContentUnwrap<F, Store> {
     async fn unwrap<'c, IS: io::IStream>(
         &mut self,
         store: &'c Store,
@@ -36,8 +36,8 @@ pub trait ContentUnwrap<F, Store>: Send + Sync {
     ) -> Result<&'c mut unwrap::Context<F, IS>>;
 }
 
-#[async_trait]
-pub trait ContentUnwrapNew<F, Store>: Send + Sync
+#[async_trait(?Send)]
+pub trait ContentUnwrapNew<F, Store>
 where
     Self: Sized,
 {

--- a/iota-streams-app/src/message/hdf.rs
+++ b/iota-streams-app/src/message/hdf.rs
@@ -180,7 +180,7 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Link> ContentSizeof<F> for HDF<Link>
 where
     F: PRP,
@@ -205,12 +205,11 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Link, Store> ContentWrap<F, Store> for HDF<Link>
 where
     F: PRP,
     Link: AbsorbExternalFallback<F>,
-    Store: Send + Sync,
 {
     async fn wrap<'c, OS: io::OStream>(
         &self,
@@ -250,12 +249,11 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Link, Store> ContentUnwrap<F, Store> for HDF<Link>
 where
     F: PRP,
     Link: AbsorbExternalFallback<F> + std::fmt::Debug + Clone,
-    Store: Send + Sync,
 {
     async fn unwrap<'c, IS: io::IStream>(
         &mut self,

--- a/iota-streams-app/src/message/link.rs
+++ b/iota-streams-app/src/message/link.rs
@@ -11,7 +11,7 @@ use crate::identifier::Identifier;
 use iota_streams_ddml::types::Bytes;
 
 /// Type of "absolute" links. For http it's the absolute URL.
-pub trait HasLink: Sized + Default + Clone + Eq + Send + Sync {
+pub trait HasLink: Sized + Default + Clone + Eq {
     /// Type of "base" links. For http it's domain name.
     type Base: Default + Clone;
 
@@ -19,7 +19,7 @@ pub trait HasLink: Sized + Default + Clone + Eq + Send + Sync {
     fn base(&self) -> &Self::Base;
 
     /// Type of "relative" links. For http it's URL path.
-    type Rel: Default + Clone + Send + Sync;
+    type Rel: Default + Clone;
 
     /// Get relative part of the link.
     fn rel(&self) -> &Self::Rel;
@@ -109,7 +109,7 @@ impl<Link: fmt::Debug> fmt::Debug for Cursor<Link> {
 }
 
 /// Abstraction-helper to generate message links.
-pub trait LinkGenerator<Link: HasLink>: Default + Send + Sync {
+pub trait LinkGenerator<Link: HasLink>: Default {
     /// Used by Author to generate a new application instance: channels address and announcement message identifier
     fn gen(&mut self, pk: &ed25519::PublicKey, idx: u64);
 

--- a/iota-streams-app/src/message/pcf.rs
+++ b/iota-streams-app/src/message/pcf.rs
@@ -115,7 +115,7 @@ impl<Content> PCF<Content> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Content> ContentSizeof<F> for PCF<Content>
 where
     F: PRP,
@@ -128,12 +128,11 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Content, Store> ContentWrap<F, Store> for PCF<Content>
 where
     F: PRP,
     Content: ContentWrap<F, Store>,
-    Store: Send + Sync,
 {
     async fn wrap<'c, OS: io::OStream>(
         &self,
@@ -146,12 +145,11 @@ where
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<F, Content, Store> ContentUnwrap<F, Store> for PCF<Content>
 where
     F: PRP,
     Content: ContentUnwrap<F, Store>,
-    Store: Send + Sync,
 {
     async fn unwrap<'c, IS: io::IStream>(
         &mut self,

--- a/iota-streams-app/src/message/preparsed.rs
+++ b/iota-streams-app/src/message/preparsed.rs
@@ -32,7 +32,6 @@ impl<'a, F, Link: Default + Clone> PreparsedMessage<'a, F, Link> {
     where
         Content: ContentUnwrap<F, Store>,
         F: PRP,
-        Store: Send + Sync,
     {
         let mut pcf = pcf::PCF::default_with_content(content);
         pcf.unwrap(store, &mut self.ctx).await?;

--- a/iota-streams-app/src/transport/bucket.rs
+++ b/iota-streams-app/src/transport/bucket.rs
@@ -90,7 +90,6 @@ where
 impl<Link, Msg> TransportDetails<Link> for BucketTransport<Link, Msg>
 where
     Link: Eq + hash::Hash + Clone + core::marker::Send + core::marker::Sync + core::fmt::Display,
-    Msg: Send + Sync,
 {
     type Details = ();
     async fn get_link_details(&mut self, _opt: &Link) -> Result<Self::Details> {

--- a/iota-streams-app/src/transport/mod.rs
+++ b/iota-streams-app/src/transport/mod.rs
@@ -10,13 +10,7 @@ use iota_streams_core::{
     Result,
 };
 
-use core::{
-    cell::RefCell,
-    marker::{
-        Send,
-        Sync,
-    },
-};
+use core::cell::RefCell;
 
 #[async_trait(?Send)]
 pub trait TransportDetails<Link> {

--- a/iota-streams-core/src/sponge/prp/prp.rs
+++ b/iota-streams-core/src/sponge/prp/prp.rs
@@ -7,8 +7,7 @@ use crate::prelude::generic_array::{
 ///
 /// Actually, it may be non-bijective as the inverse transform is not used in sponge construction.
 #[allow(clippy::upper_case_acronyms)]
-pub trait PRP: Sized + Default + Clone + Send + Sync //+ From<Vec<u8>> + Into<Vec<u8>>
-{
+pub trait PRP: Sized + Default + Clone {
     /// Size of the outer state in bytes.
     /// In other words, size of data chunk that PRP can process in one transform.
     type RateSize: ArrayLength<u8>;

--- a/iota-streams-ddml/src/command/wrap/fork.rs
+++ b/iota-streams-ddml/src/command/wrap/fork.rs
@@ -9,7 +9,7 @@ use iota_streams_core::sponge::prp::PRP;
 
 impl<C, F: PRP, OS: io::OStream> Fork<C> for Context<F, OS>
 where
-    C: for<'a> FnMut(&'a mut Self) -> Result<&'a mut Self> + Send,
+    C: for<'a> FnMut(&'a mut Self) -> Result<&'a mut Self>,
 {
     fn fork(&mut self, mut cont: C) -> Result<&mut Self> {
         let saved_fork = self.spongos.fork();

--- a/iota-streams-ddml/src/io.rs
+++ b/iota-streams-ddml/src/io.rs
@@ -15,7 +15,7 @@ use iota_streams_core::{
 };
 
 /// Write
-pub trait OStream: Send + Sync {
+pub trait OStream {
     /// Try advance and panic in case of error.
     fn advance<'a>(&'a mut self, n: usize) -> &'a mut [u8] {
         let r = self.try_advance(n);
@@ -36,7 +36,7 @@ pub trait OStream: Send + Sync {
 }
 
 /// Read
-pub trait IStream: Send + Sync {
+pub trait IStream {
     /// Try advance and panic in case of error.
     fn advance<'a>(&'a mut self, n: usize) -> &'a [u8] {
         let r = self.try_advance(n);

--- a/iota-streams-ddml/src/link_store.rs
+++ b/iota-streams-ddml/src/link_store.rs
@@ -26,7 +26,7 @@ use iota_streams_core::{
 /// The `link` type is generic and transport-specific. Links can be address+tag pair
 /// when messages are published in the Tangle. Or links can be a URL when HTTP is used.
 /// Or links can be a message sequence number in a stream/socket.
-pub trait LinkStore<F, Link>: Send + Sync {
+pub trait LinkStore<F, Link> {
     /// Additional data associated with the current message link/spongos state.
     /// This type is implementation specific, meaning different configurations
     /// of a Streams Application can use different Info types.
@@ -70,12 +70,7 @@ impl<F, Link, Info> Default for EmptyLinkStore<F, Link, Info> {
     }
 }
 
-impl<F, Link, Info> LinkStore<F, Link> for EmptyLinkStore<F, Link, Info>
-where
-    F: Send + Sync,
-    Link: Send + Sync,
-    Info: Send + Sync,
-{
+impl<F, Link, Info> LinkStore<F, Link> for EmptyLinkStore<F, Link, Info> {
     type Info = Info;
     fn update(&mut self, _link: &Link, _spongos: Spongos<F>, _info: Self::Info) -> Result<()> {
         Ok(())
@@ -114,8 +109,8 @@ impl<F: PRP, Link, Info> SingleLinkStore<F, Link, Info> {
 
 impl<F: PRP, Link, Info> LinkStore<F, Link> for SingleLinkStore<F, Link, Info>
 where
-    Link: Clone + Eq + Display + Send + Sync,
-    Info: Clone + Send + Sync,
+    Link: Clone + Eq + Display,
+    Info: Clone,
 {
     type Info = Info;
     fn lookup(&self, link: &Link) -> Result<(Spongos<F>, Self::Info)> {
@@ -147,8 +142,7 @@ pub struct DefaultLinkStore<F: PRP, Link, Info> {
 
 impl<F: PRP, Link, Info> Default for DefaultLinkStore<F, Link, Info>
 where
-    Link: Eq + hash::Hash + Send + Sync,
-    Info: Send + Sync,
+    Link: Eq + hash::Hash,
 {
     fn default() -> Self {
         Self {
@@ -160,8 +154,8 @@ where
 
 impl<F: PRP, Link, Info> LinkStore<F, Link> for DefaultLinkStore<F, Link, Info>
 where
-    Link: Eq + hash::Hash + Clone + Display + Send + Sync,
-    Info: Clone + Send + Sync,
+    Link: Eq + hash::Hash + Clone + Display,
+    Info: Clone,
 {
     type Info = Info;
 

--- a/iota-streams-ddml/src/types/fallback.rs
+++ b/iota-streams-ddml/src/types/fallback.rs
@@ -42,7 +42,7 @@ impl<T> AsMut<T> for Fallback<T> {
 }
 
 /// Trait allows for custom (non-standard DDML) types to be Absorb.
-pub trait AbsorbFallback<F>: Send + Sync {
+pub trait AbsorbFallback<F> {
     fn sizeof_absorb(&self, ctx: &mut sizeof::Context<F>) -> Result<()>;
     fn wrap_absorb<OS: io::OStream>(&self, ctx: &mut wrap::Context<F, OS>) -> Result<()>;
     fn unwrap_absorb<IS: io::IStream>(&mut self, ctx: &mut unwrap::Context<F, IS>) -> Result<()>;
@@ -53,7 +53,7 @@ pub trait AbsorbFallback<F>: Send + Sync {
 /// in DDML and domain specific.
 ///
 /// Note, that "absolute" links are absorbed in the message header.
-pub trait AbsorbExternalFallback<F>: Send + Sync {
+pub trait AbsorbExternalFallback<F> {
     fn sizeof_absorb_external(&self, ctx: &mut sizeof::Context<F>) -> Result<()>;
     fn wrap_absorb_external<OS: io::OStream>(&self, ctx: &mut wrap::Context<F, OS>) -> Result<()>;
     fn unwrap_absorb_external<IS: io::IStream>(&self, ctx: &mut unwrap::Context<F, IS>) -> Result<()>;


### PR DESCRIPTION
Trait bounds should generally be pushed to the latest moment when they are actually needed. That is, the functions that manipulate the data and that actually require the bound. It is usually avoided (to the reasonable extend) to put trait bounds in the type parameters of data types and trait declarations, as they unleash an unergonomic "trait bound hell" and are usually overly restrictive.

Some relevant references:
- [API Guidelines]
- [discussion API Guidelines]
- [flate2 case]
- [Haskell Programming Guidelines]

In this case, the trait bounds "Sync" and "Send" are already enforced (if necessary) when the async runtime actually schedule the Futures, and it is at this point (if actually enforced by the runtime) that all the types and intermediate functions that manipulate those types are required to enforce these markers; However, if at any point of the rabbit hole a type bound is placed on the data, hell breaks loose and all types that touch the bounded type get contaminated. [Implied bounds RFC] might mitigate the issue, but for the time being, this convention is gold one of those that is "all or nothing", because of the "viral" effect.

[API Guidelines]: https://rust-lang.github.io/api-guidelines/future-proofing.html#data-structures-do-not-duplicate-derived-trait-bounds-c-struct-bounds
[discussion API Guidelines]: https://github.com/rust-lang/api-guidelines/issues/6
[Haskell Programming Guidelines]: https://wiki.haskell.org/Programming_guidelines#Types
[flate2 case]: https://github.com/rust-lang/flate2-rs/issues/88
[Implied bounds RFC]: https://github.com/rust-lang/rust/issues/44491