### PR TITLE
Remove synchronization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,12 @@ exclude = [
 default = ["std", "client"]
 # Enable `std` feature in dependencies
 std = ["iota-streams-core/std", "iota-streams-core-edsig/std", "iota-streams-ddml/std", "iota-streams-app/std", "iota-streams-app-channels/std"]
-no-std = ["iota-streams-core/no-std"]
 tangle = ["iota-streams-app/tangle", "iota-streams-app-channels/tangle"]
 client = ["iota-streams-app/client", "tangle"]
 wasm-client = ["iota-streams-app/wasm-client", "iota-streams-app-channels/wasm-client", "tangle"]
 err-location-log = ["iota-streams-core/err-location-log"]
+sync-spin = ["iota-streams-app/sync-spin", "iota-streams-core/sync-spin"]
+sync-parking-lot = ["iota-streams-app/sync-parking-lot", "std", "iota-streams-core/sync-parking-lot"]
 
 [dependencies]
 iota-streams-core = { version = "0.3.0", path = "iota-streams-core", default-features = false }

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -4,7 +4,7 @@ project(iota_streams_c LANGUAGES C)
 include(FetchContent)
 
 option(NO_STD "Enable no_std build, without iota_client" OFF)
-option(SYNC_CLIENT "Enable sync transport via iota_client" ON)
+option(IOTA_CLIENT "Enable transport via iota_client" ON)
 option(STATIC "Build static library" OFF)
 option(RELEASE "Build release library (defaults to release)" ON)
 
@@ -20,7 +20,7 @@ if(${IOTA_CLIENT})
   set(cargo_features "${cargo_features}client")
 endif(${IOTA_CLIENT})
 
-message("NO_STD=${NO_STD} SYNC_CLIENT=${SYNC_CLIENT} STATIC=${STATIC} RELEASE=${RELEASE}")
+message("NO_STD=${NO_STD} IOTA_CLIENT=${IOTA_CLIENT} STATIC=${STATIC} RELEASE=${RELEASE}")
 
 include_directories(include/)
 

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub type Author = iota_streams::app_channels::api::tangle::Author<TransportWrap>;
+pub type Author = iota_streams::app_channels::api::tangle::Author<Transport>;
 
 /// Generate a new Author Instance
 #[no_mangle]
@@ -8,7 +8,7 @@ pub unsafe extern "C" fn auth_new(
     c_author: *mut *mut Author,
     c_seed: *const c_char,
     channel_type: uint8_t,
-    transport: *mut TransportWrap,
+    transport: *mut Transport,
 ) -> Err {
     if c_seed == null() {
         return Err::NullArgument;
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn auth_recover(
     c_seed: *const c_char,
     c_ann_address: *const Address,
     channel_type: uint8_t,
-    transport: *mut TransportWrap,
+    transport: *mut Transport,
 ) -> Err {
     if c_seed == null() {
         return Err::NullArgument;
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn auth_import(
     c_author: *mut *mut Author,
     buffer: Buffer,
     c_password: *const c_char,
-    transport: *mut TransportWrap,
+    transport: *mut Transport,
 ) -> Err {
     if c_password == null() {
         return Err::NullArgument;

--- a/bindings/c/src/api/auth.rs
+++ b/bindings/c/src/api/auth.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub type Author = iota_streams::app_channels::api::tangle::Author<Transport>;
+pub type Author = iota_streams::app_channels::api::tangle::Author<TransportWrap>;
 
 /// Generate a new Author Instance
 #[no_mangle]
@@ -8,7 +8,7 @@ pub unsafe extern "C" fn auth_new(
     c_author: *mut *mut Author,
     c_seed: *const c_char,
     channel_type: uint8_t,
-    transport: *mut Transport,
+    transport: *mut TransportWrap,
 ) -> Err {
     if c_seed == null() {
         return Err::NullArgument;
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn auth_recover(
     c_seed: *const c_char,
     c_ann_address: *const Address,
     channel_type: uint8_t,
-    transport: *mut Transport,
+    transport: *mut TransportWrap,
 ) -> Err {
     if c_seed == null() {
         return Err::NullArgument;
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn auth_import(
     c_author: *mut *mut Author,
     buffer: Buffer,
     c_password: *const c_char,
-    transport: *mut Transport,
+    transport: *mut TransportWrap,
 ) -> Err {
     if c_password == null() {
         return Err::NullArgument;

--- a/bindings/c/src/api/mod.rs
+++ b/bindings/c/src/api/mod.rs
@@ -159,10 +159,10 @@ pub extern "C" fn drop_unwrapped_messages(ms: *const UnwrappedMessages) {
 }
 
 #[cfg(feature = "client")]
-pub type Transport = iota_streams::app::transport::tangle::client::Client;
+pub type TransportWrap = iota_streams::app::transport::tangle::client::Client;
 
 #[cfg(not(feature = "client"))]
-pub type Transport = Rc<RefCell<BucketTransport>>;
+pub type TransportWrap = Rc<RefCell<BucketTransport>>;
 
 static INSTANCE: OnceCell<Runtime> = OnceCell::new();
 
@@ -172,20 +172,20 @@ pub fn run_async<C: Future>(cb: C) -> C::Output {
 }
 
 #[no_mangle]
-pub extern "C" fn transport_new() -> *mut Transport {
-    safe_into_mut_ptr(Transport::default())
+pub extern "C" fn transport_new() -> *mut TransportWrap {
+    safe_into_mut_ptr(TransportWrap::default())
 }
 
 #[no_mangle]
-pub extern "C" fn transport_drop(tsp: *mut Transport) {
+pub extern "C" fn transport_drop(tsp: *mut TransportWrap) {
     safe_drop_mut_ptr(tsp)
 }
 
 #[cfg(feature = "client")]
 #[no_mangle]
-pub unsafe extern "C" fn transport_client_new_from_url(c_url: *const c_char) -> *mut Transport {
+pub unsafe extern "C" fn transport_client_new_from_url(c_url: *const c_char) -> *mut TransportWrap {
     let url = CStr::from_ptr(c_url).to_str().unwrap();
-    safe_into_mut_ptr(Transport::new_from_url(url))
+    safe_into_mut_ptr(TransportWrap::new_from_url(url))
 }
 
 #[cfg(feature = "client")]
@@ -347,7 +347,7 @@ mod client_details {
     #[no_mangle]
     pub unsafe extern "C" fn transport_get_link_details(
         r: *mut TransportDetails,
-        tsp: *mut Transport,
+        tsp: *mut TransportWrap,
         link: *const Address,
     ) -> Err {
         r.as_mut().map_or(Err::NullArgument, |r| {

--- a/bindings/c/src/api/sub.rs
+++ b/bindings/c/src/api/sub.rs
@@ -1,13 +1,13 @@
 use super::*;
 
-pub type Subscriber = iota_streams::app_channels::api::tangle::Subscriber<Transport>;
+pub type Subscriber = iota_streams::app_channels::api::tangle::Subscriber<TransportWrap>;
 
 /// Create a new subscriber
 #[no_mangle]
 pub unsafe extern "C" fn sub_new(
     c_sub: *mut *mut Subscriber,
     c_seed: *const c_char,
-    transport: *mut Transport,
+    transport: *mut TransportWrap,
 ) -> Err {
     if c_seed == null() {
         return Err::NullArgument;
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn sub_recover(
     c_sub: *mut *mut Subscriber,
     c_seed: *const c_char,
     c_ann_address: *const Address,
-    transport: *mut Transport,
+    transport: *mut TransportWrap,
 ) -> Err {
     if c_seed == null() {
         return Err::NullArgument;
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn sub_import(
     c_sub: *mut *mut Subscriber,
     buffer: Buffer,
     c_password: *const c_char,
-    transport: *mut Transport,
+    transport: *mut TransportWrap,
 ) -> Err {
     if c_password == null() {
         return Err::NullArgument;

--- a/bindings/c/src/api/sub.rs
+++ b/bindings/c/src/api/sub.rs
@@ -1,13 +1,13 @@
 use super::*;
 
-pub type Subscriber = iota_streams::app_channels::api::tangle::Subscriber<TransportWrap>;
+pub type Subscriber = iota_streams::app_channels::api::tangle::Subscriber<Transport>;
 
 /// Create a new subscriber
 #[no_mangle]
 pub unsafe extern "C" fn sub_new(
     c_sub: *mut *mut Subscriber,
     c_seed: *const c_char,
-    transport: *mut TransportWrap,
+    transport: *mut Transport,
 ) -> Err {
     if c_seed == null() {
         return Err::NullArgument;
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn sub_recover(
     c_sub: *mut *mut Subscriber,
     c_seed: *const c_char,
     c_ann_address: *const Address,
-    transport: *mut TransportWrap,
+    transport: *mut Transport,
 ) -> Err {
     if c_seed == null() {
         return Err::NullArgument;
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn sub_import(
     c_sub: *mut *mut Subscriber,
     buffer: Buffer,
     c_password: *const c_char,
-    transport: *mut TransportWrap,
+    transport: *mut Transport,
 ) -> Err {
     if c_password == null() {
         return Err::NullArgument;

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -17,7 +17,7 @@ wasm-opt = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1.6"
 js-sys = "0.3.46"

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -44,7 +44,8 @@ use iota_streams::{
 
 #[wasm_bindgen]
 pub struct Author {
-    author: Rc<RefCell<ApiAuthor<ApiClient>>>,
+    // Don't alias away the ugliness, so we don't forget
+    author: Rc<RefCell<ApiAuthor<Rc<RefCell<ApiClient>>>>>,
 }
 
 #[wasm_bindgen]
@@ -53,7 +54,8 @@ impl Author {
     pub fn new(seed: String, options: SendOptions, implementation: ChannelType) -> Author {
         let mut client = ApiClient::new_from_url(&options.url());
         client.set_send_options(options.into());
-        let author = Rc::new(RefCell::new(ApiAuthor::new(&seed, implementation.into(), client)));
+        let transport = Rc::new(RefCell::new(client));
+        let author = Rc::new(RefCell::new(ApiAuthor::new(&seed, implementation.into(), transport)));
         Author { author }
     }
 

--- a/bindings/wasm/src/author/authorw.rs
+++ b/bindings/wasm/src/author/authorw.rs
@@ -33,8 +33,6 @@ use iota_streams::{
     },
     core::{
         prelude::{
-            Arc,
-            Mutex,
             Rc,
             String,
             ToString,
@@ -46,7 +44,7 @@ use iota_streams::{
 
 #[wasm_bindgen]
 pub struct Author {
-    author: Rc<RefCell<ApiAuthor<ClientWrap>>>,
+    author: Rc<RefCell<ApiAuthor<ApiClient>>>,
 }
 
 #[wasm_bindgen]
@@ -55,9 +53,7 @@ impl Author {
     pub fn new(seed: String, options: SendOptions, implementation: ChannelType) -> Author {
         let mut client = ApiClient::new_from_url(&options.url());
         client.set_send_options(options.into());
-        let transport = Arc::new(Mutex::new(client));
-
-        let author = Rc::new(RefCell::new(ApiAuthor::new(&seed, implementation.into(), transport)));
+        let author = Rc::new(RefCell::new(ApiAuthor::new(&seed, implementation.into(), client)));
         Author { author }
     }
 

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -26,8 +26,6 @@ use iota_streams::{
     },
     core::{
         prelude::{
-            Arc,
-            Mutex,
             Rc,
             String,
         },
@@ -38,7 +36,7 @@ use iota_streams::{
 
 #[wasm_bindgen]
 pub struct Subscriber {
-    subscriber: Rc<RefCell<ApiSubscriber<ClientWrap>>>,
+    subscriber: Rc<RefCell<ApiSubscriber<ApiClient>>>,
 }
 
 #[wasm_bindgen]
@@ -47,9 +45,7 @@ impl Subscriber {
     pub fn new(seed: String, options: SendOptions) -> Subscriber {
         let mut client = ApiClient::new_from_url(&options.url());
         client.set_send_options(options.into());
-        let transport = Arc::new(Mutex::new(client));
-
-        let subscriber = Rc::new(RefCell::new(ApiSubscriber::new(&seed, transport)));
+        let subscriber = Rc::new(RefCell::new(ApiSubscriber::new(&seed, client)));
         Subscriber { subscriber }
     }
 

--- a/bindings/wasm/src/subscriber/subscriberw.rs
+++ b/bindings/wasm/src/subscriber/subscriberw.rs
@@ -36,7 +36,8 @@ use iota_streams::{
 
 #[wasm_bindgen]
 pub struct Subscriber {
-    subscriber: Rc<RefCell<ApiSubscriber<ApiClient>>>,
+    // Don't alias away the ugliness, so we don't forget
+    subscriber: Rc<RefCell<ApiSubscriber<Rc<RefCell<ApiClient>>>>>,
 }
 
 #[wasm_bindgen]
@@ -45,7 +46,8 @@ impl Subscriber {
     pub fn new(seed: String, options: SendOptions) -> Subscriber {
         let mut client = ApiClient::new_from_url(&options.url());
         client.set_send_options(options.into());
-        let subscriber = Rc::new(RefCell::new(ApiSubscriber::new(&seed, client)));
+        let transport = Rc::new(RefCell::new(client));
+        let subscriber = Rc::new(RefCell::new(ApiSubscriber::new(&seed, transport)));
         Subscriber { subscriber }
     }
 

--- a/bindings/wasm/src/types/mod.rs
+++ b/bindings/wasm/src/types/mod.rs
@@ -13,7 +13,6 @@ use iota_streams::{
                 },
                 MilestoneResponse as ApiMilestoneResponse,
             },
-            Client,
             Details as ApiDetails,
             SendOptions as ApiSendOptions,
         },
@@ -27,8 +26,6 @@ use iota_streams::{
     },
     core::{
         prelude::{
-            Arc,
-            Mutex,
             String,
             ToString,
         },
@@ -155,8 +152,6 @@ impl Address {
         }
     }
 }
-
-pub type ClientWrap = Arc<Mutex<Client>>;
 
 impl TryFrom<Address> for ApiAddress {
     type Error = JsValue;

--- a/bindings/wasm/src/user/userw.rs
+++ b/bindings/wasm/src/user/userw.rs
@@ -10,11 +10,15 @@ use iota_streams::{
         TransportOptions,
     },
     app_channels::api::tangle::Address as ApiAddress,
+    core::prelude::{
+        Rc,
+        RefCell,
+    },
 };
 
 #[wasm_bindgen]
 #[derive(Clone)]
-pub struct Client(pub(crate) ApiClient);
+pub struct Client(pub(crate) Rc<RefCell<ApiClient>>);
 
 #[wasm_bindgen]
 impl Client {
@@ -22,7 +26,8 @@ impl Client {
     pub fn new(node: String, options: SendOptions) -> Self {
         let mut client = ApiClient::new_from_url(&node);
         client.set_send_options(options.into());
-        Client(client)
+        let transport = Rc::new(RefCell::new(client));
+        Client(transport)
     }
 
     #[wasm_bindgen(catch)]
@@ -43,13 +48,14 @@ impl Client {
 
 impl Client {
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_inner(self) -> ApiClient {
+    pub fn to_inner(self) -> Rc<RefCell<ApiClient>> {
         self.0
     }
 }
 
 impl From<ApiClient> for Client {
     fn from(client: ApiClient) -> Self {
-        Client(client)
+        let transport = Rc::new(RefCell::new(client));
+        Client(transport)
     }
 }

--- a/bindings/wasm/src/user/userw.rs
+++ b/bindings/wasm/src/user/userw.rs
@@ -10,15 +10,11 @@ use iota_streams::{
         TransportOptions,
     },
     app_channels::api::tangle::Address as ApiAddress,
-    core::prelude::{
-        Arc,
-        Mutex,
-    },
 };
 
 #[wasm_bindgen]
 #[derive(Clone)]
-pub struct Client(pub(crate) ClientWrap);
+pub struct Client(pub(crate) ApiClient);
 
 #[wasm_bindgen]
 impl Client {
@@ -26,9 +22,7 @@ impl Client {
     pub fn new(node: String, options: SendOptions) -> Self {
         let mut client = ApiClient::new_from_url(&node);
         client.set_send_options(options.into());
-        let transport = Arc::new(Mutex::new(client));
-
-        Client(transport)
+        Client(client)
     }
 
     #[wasm_bindgen(catch)]
@@ -49,15 +43,13 @@ impl Client {
 
 impl Client {
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_inner(self) -> ClientWrap {
+    pub fn to_inner(self) -> ApiClient {
         self.0
     }
 }
 
 impl From<ApiClient> for Client {
     fn from(client: ApiClient) -> Self {
-        let transport = Arc::new(Mutex::new(client));
-
-        Client(transport)
+        Client(client)
     }
 }

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -14,8 +14,8 @@ use iota_streams::{
     },
     core::{
         prelude::{
-            Arc,
-            Mutex,
+            Rc,
+            RefCell,
             String,
         },
         Result,
@@ -83,7 +83,10 @@ async fn main_pure() {
     println!("#######################################");
     println!("\n");
 
-    let transport = Arc::new(Mutex::new(transport));
+    // BucketTransport is an in-memory storage that needs to be shared between all the users,
+    // hence the Rc<RefCell<BucketTransport>>
+    let transport = Rc::new(RefCell::new(transport));
+
     run_single_branch_test(transport.clone(), "PURESEEDA").await;
     run_single_depth_test(transport.clone(), "PURESEEDB").await;
     run_multi_branch_test(transport.clone(), "PURESEEDC").await;

--- a/iota-streams-app-channels/src/api/tangle/author.rs
+++ b/iota-streams-app-channels/src/api/tangle/author.rs
@@ -162,7 +162,7 @@ impl<Trans: Transport + Clone> Author<Trans> {
         let retrieved: Message = author.user.transport.recv_message(announcement).await?;
         panic_if_not(retrieved.binary == ann.message);
 
-        author.user.commit_wrapped(ann.wrapped, MsgInfo::Announce).await?;
+        author.user.commit_wrapped(ann.wrapped, MsgInfo::Announce)?;
         author.sync_state().await;
 
         Ok(author)

--- a/iota-streams-app-channels/src/api/tangle/user.rs
+++ b/iota-streams-app-channels/src/api/tangle/user.rs
@@ -155,8 +155,8 @@ impl<Trans> User<Trans> {
     ///  # Arguments
     ///  * `wrapped` - A wrapped message intended to be committed to the link store
     ///  * `info` - The type of wrapped message being committed to the link store
-    pub async fn commit_wrapped(&mut self, wrapped: WrapState, info: MsgInfo) -> Result<Address> {
-        self.user.commit_wrapped(wrapped, info).await
+    pub fn commit_wrapped(&mut self, wrapped: WrapState, info: MsgInfo) -> Result<Address> {
+        self.user.commit_wrapped(wrapped, info)
     }
 
     pub async fn export(&self, flag: u8, pwd: &str) -> Result<Vec<u8>> {
@@ -217,7 +217,7 @@ impl<Trans: Transport + Clone> User<Trans> {
     /// Send a message without using sequencing logic. Reserved for Announce and Subscribe messages
     async fn send_message(&mut self, msg: WrappedMessage, info: MsgInfo) -> Result<Address> {
         self.transport.send_message(&Message::new(msg.message)).await?;
-        self.commit_wrapped(msg.wrapped, info).await
+        self.commit_wrapped(msg.wrapped, info)
     }
 
     /// Send a message using sequencing logic.
@@ -234,7 +234,7 @@ impl<Trans: Transport + Clone> User<Trans> {
     ) -> Result<(Address, Option<Address>)> {
         // Send & commit original message
         self.transport.send_message(&Message::new(msg.message)).await?;
-        let msg_link = self.commit_wrapped(msg.wrapped, info).await?;
+        let msg_link = self.commit_wrapped(msg.wrapped, info)?;
 
         // Send & commit associated sequence message
         let seq = self.user.wrap_sequence(ref_link).await?;

--- a/iota-streams-app/Cargo.toml
+++ b/iota-streams-app/Cargo.toml
@@ -19,6 +19,8 @@ client = ["iota-client/default", "tangle", "std"]
 # `iota-client` support is implemented as a feature (as opposed to a separate crate) in order to
 # implement Transport for iota_client::Client.
 wasm-client = ["iota-client/wasm", "chrono/wasmbind", "tangle", "std"]
+sync-parking-lot = ["iota-streams-core/sync-parking-lot"]
+sync-spin = ["iota-streams-core/sync-spin"]
 
 [lib]
 name = "iota_streams_app"
@@ -31,8 +33,6 @@ iota-streams-ddml = { version = "0.2.1", path = "../iota-streams-ddml", default-
 
 # anyhow and chrono are kept in sync with versions used in iota-client
 anyhow = { version = "1.0.26", default-features = false }
-wasm-timer = { version = "0.2.5", optional = true }
-js-sys = { version = "0.3.46", optional = true }
 chrono = { version = "0.4.11", default-features = false, optional = true }
 hex = { version = "0.4", default-features = false, optional = false }
 futures = { version = "0.3.8", default-features = false, features = ["executor"], optional = true }

--- a/iota-streams-app/src/message/prepared.rs
+++ b/iota-streams-app/src/message/prepared.rs
@@ -2,10 +2,6 @@ use iota_streams_core::Result;
 
 use super::*;
 use iota_streams_core::{
-    prelude::{
-        sync::RwLock,
-        Arc,
-    },
     sponge::prp::PRP,
     try_or,
     Errors::OutputStreamNotFullyConsumed,
@@ -15,27 +11,24 @@ use iota_streams_ddml::{
         sizeof,
         wrap,
     },
-    link_store::LinkStore,
     types::*,
 };
 
 /// Message context prepared for wrapping.
-pub struct PreparedMessage<F, Link: Default, Store, Content> {
-    store: Arc<RwLock<Store>>,
+pub struct PreparedMessage<F, Link: Default, Content> {
     pub header: HDF<Link>,
     pub content: PCF<Content>,
     _phantom: core::marker::PhantomData<F>,
 }
 
-impl<F, Link: Default, Store, Content> PreparedMessage<F, Link, Store, Content> {
-    pub fn new(store: Arc<RwLock<Store>>, header: HDF<Link>, content: Content) -> Self {
+impl<F, Link: Default, Content> PreparedMessage<F, Link, Content> {
+    pub fn new(header: HDF<Link>, content: Content) -> Self {
         let content = pcf::PCF::new_final_frame()
             .with_payload_frame_num(1)
             .unwrap()
             .with_content(content);
 
         Self {
-            store,
             header,
             content,
             _phantom: core::marker::PhantomData,
@@ -43,16 +36,18 @@ impl<F, Link: Default, Store, Content> PreparedMessage<F, Link, Store, Content> 
     }
 }
 
-impl<F, Link, Store, Content> PreparedMessage<F, Link, Store, Content>
+impl<'a, F, Link, Content> PreparedMessage<F, Link, Content>
 where
     F: PRP,
     Link: HasLink + AbsorbExternalFallback<F> + Clone + Default,
-    <Link as HasLink>::Rel: Eq + SkipFallback<F>,
-    Store: LinkStore<F, <Link as HasLink>::Rel>,
-    HDF<Link>: ContentWrap<F, Store>,
-    Content: ContentWrap<F, Store>,
+    Link::Rel: Eq + SkipFallback<F>,
+    // Store: LinkStore<F, <Link as HasLink>::Rel>,
 {
-    pub async fn wrap(&self) -> Result<WrappedMessage<F, Link>> {
+    pub async fn wrap<Store>(&self, store: &Store) -> Result<WrappedMessage<F, Link>>
+    where
+        HDF<Link>: ContentWrap<F, Store>,
+        Content: ContentWrap<F, Store>,
+    {
         let buf_size = {
             let mut ctx = sizeof::Context::<F>::new();
             self.header.sizeof(&mut ctx).await?;
@@ -64,8 +59,8 @@ where
 
         let spongos = {
             let mut ctx = wrap::Context::new(&mut buf[..]);
-            self.header.wrap(&self.store.write().unwrap(), &mut ctx).await?;
-            self.content.wrap(&self.store.write().unwrap(), &mut ctx).await?;
+            self.header.wrap(store, &mut ctx).await?;
+            self.content.wrap(store, &mut ctx).await?;
             try_or!(ctx.stream.is_empty(), OutputStreamNotFullyConsumed(ctx.stream.len()))?;
             ctx.spongos
         };

--- a/iota-streams-app/src/message/preparsed.rs
+++ b/iota-streams-app/src/message/preparsed.rs
@@ -1,18 +1,9 @@
 use iota_streams_core::Result;
 
-use core::{
-    borrow::Borrow,
-    fmt,
-};
+use core::fmt;
 
 use super::*;
-use iota_streams_core::{
-    prelude::{
-        sync::RwLock,
-        Arc,
-    },
-    sponge::prp::PRP,
-};
+use iota_streams_core::sponge::prp::PRP;
 use iota_streams_ddml::command::unwrap;
 
 /// Message context preparsed for unwrapping.
@@ -32,7 +23,7 @@ impl<'a, F, Link: Default + Clone> PreparsedMessage<'a, F, Link> {
 
     pub async fn unwrap<Store, Content>(
         mut self,
-        store: Arc<RwLock<Store>>,
+        store: &Store,
         content: Content,
     ) -> Result<UnwrappedMessage<F, Link, Content>>
     where
@@ -40,7 +31,7 @@ impl<'a, F, Link: Default + Clone> PreparsedMessage<'a, F, Link> {
         F: PRP,
     {
         let mut pcf = pcf::PCF::default_with_content(content);
-        pcf.unwrap(store.write().unwrap().borrow(), &mut self.ctx).await?;
+        pcf.unwrap(store, &mut self.ctx).await?;
         // Discard what's left of `self.ctx.stream`
         Ok(UnwrappedMessage {
             link: self.header.link,

--- a/iota-streams-app/src/message/unwrapped.rs
+++ b/iota-streams-app/src/message/unwrapped.rs
@@ -1,15 +1,9 @@
 use iota_streams_core::Result;
 
 use super::*;
-use iota_streams_core::{
-    prelude::{
-        sync::RwLock,
-        Arc,
-    },
-    sponge::{
-        prp::PRP,
-        spongos::Spongos,
-    },
+use iota_streams_core::sponge::{
+    prp::PRP,
+    spongos::Spongos,
 };
 use iota_streams_ddml::link_store::LinkStore;
 
@@ -26,16 +20,12 @@ where
     Link: HasLink,
 {
     /// Save link for the current unwrapped message and associated info into the store.
-    pub fn commit<Store>(
-        mut self,
-        store: Arc<RwLock<Store>>,
-        info: <Store as LinkStore<F, <Link as HasLink>::Rel>>::Info,
-    ) -> Result<Content>
+    pub fn commit<Store>(mut self, store: &mut Store, info: Store::Info) -> Result<Content>
     where
-        Store: LinkStore<F, <Link as HasLink>::Rel>,
+        Store: LinkStore<F, Link::Rel>,
     {
         self.spongos.commit();
-        store.write().unwrap().update(self.link.rel(), self.spongos, info)?;
+        store.update(self.link.rel(), self.spongos, info)?;
         Ok(self.pcf.content)
     }
 }

--- a/iota-streams-app/src/message/wrapped.rs
+++ b/iota-streams-app/src/message/wrapped.rs
@@ -2,15 +2,9 @@ use core::fmt;
 use iota_streams_core::Result;
 
 use super::*;
-use iota_streams_core::{
-    prelude::{
-        sync::RwLock,
-        Arc,
-    },
-    sponge::{
-        prp::PRP,
-        spongos::Spongos,
-    },
+use iota_streams_core::sponge::{
+    prp::PRP,
+    spongos::Spongos,
 };
 use iota_streams_ddml::link_store::LinkStore;
 
@@ -20,19 +14,18 @@ pub struct WrapState<F, Link> {
     pub(crate) spongos: Spongos<F>,
 }
 
-impl<F: PRP, Link: HasLink> WrapState<F, Link> {
+impl<F, Link> WrapState<F, Link>
+where
+    F: PRP,
+    Link: HasLink,
+{
     /// Save link for the current wrapped message and associated info into the store.
-    pub fn commit<Store>(
-        mut self,
-        store: Arc<RwLock<Store>>,
-        info: <Store as LinkStore<F, <Link as HasLink>::Rel>>::Info,
-    ) -> Result<Link>
+    pub fn commit<Store>(mut self, store: &mut Store, info: Store::Info) -> Result<Link>
     where
-        Link: HasLink,
-        Store: LinkStore<F, <Link as HasLink>::Rel>,
+        Store: LinkStore<F, Link::Rel>,
     {
         self.spongos.commit();
-        store.write().unwrap().update(self.link.rel(), self.spongos, info)?;
+        store.update(self.link.rel(), self.spongos, info)?;
         Ok(self.link)
     }
 }

--- a/iota-streams-app/src/transport/mod.rs
+++ b/iota-streams-app/src/transport/mod.rs
@@ -62,7 +62,7 @@ impl<Tsp: TransportOptions> TransportOptions for Rc<RefCell<Tsp>> {
 impl<Link, Tsp: TransportDetails<Link>> TransportDetails<Link> for Rc<RefCell<Tsp>> {
     type Details = <Tsp as TransportDetails<Link>>::Details;
     async fn get_link_details(&mut self, link: &Link) -> Result<Self::Details> {
-        self.get_link_details(link).await
+        self.borrow_mut().get_link_details(link).await
     }
 }
 

--- a/iota-streams-app/src/transport/mod.rs
+++ b/iota-streams-app/src/transport/mod.rs
@@ -1,9 +1,9 @@
 use iota_streams_core::{
     async_trait,
     prelude::{
-        Arc,
         Box,
-        Mutex,
+        Rc,
+        RefCell,
         Vec,
     },
     Result,
@@ -40,47 +40,110 @@ pub trait Transport<Link, Msg>: TransportOptions + TransportDetails<Link> {
     async fn recv_message(&mut self, link: &Link) -> Result<Msg>;
 }
 
-impl<Tsp: TransportOptions> TransportOptions for Arc<Mutex<Tsp>> {
+impl<Tsp: TransportOptions> TransportOptions for Rc<RefCell<Tsp>> {
     type SendOptions = <Tsp as TransportOptions>::SendOptions;
     fn get_send_options(&self) -> Self::SendOptions {
-        (&*self).lock().get_send_options()
+        self.borrow_mut().get_send_options()
     }
     fn set_send_options(&mut self, opt: Self::SendOptions) {
-        (&*self).lock().set_send_options(opt)
+        self.borrow_mut().set_send_options(opt)
     }
 
     type RecvOptions = <Tsp as TransportOptions>::RecvOptions;
     fn get_recv_options(&self) -> Self::RecvOptions {
-        (&*self).lock().get_recv_options()
+        self.borrow_mut().get_recv_options()
     }
     fn set_recv_options(&mut self, opt: Self::RecvOptions) {
-        (&*self).lock().set_recv_options(opt)
+        self.borrow_mut().set_recv_options(opt)
     }
 }
 
 #[async_trait(?Send)]
-impl<Link, Tsp: TransportDetails<Link>> TransportDetails<Link> for Arc<Mutex<Tsp>> {
+impl<Link, Tsp: TransportDetails<Link>> TransportDetails<Link> for Rc<RefCell<Tsp>> {
     type Details = <Tsp as TransportDetails<Link>>::Details;
     async fn get_link_details(&mut self, link: &Link) -> Result<Self::Details> {
-        (&*self).lock().get_link_details(link).await
+        self.get_link_details(link).await
     }
 }
 
 #[async_trait(?Send)]
-impl<Link, Msg, Tsp: Transport<Link, Msg>> Transport<Link, Msg> for Arc<Mutex<Tsp>> {
+impl<Link, Msg, Tsp: Transport<Link, Msg>> Transport<Link, Msg> for Rc<RefCell<Tsp>> {
     // Send a message.
     async fn send_message(&mut self, msg: &Msg) -> Result<()> {
-        (&*self).lock().send_message(msg).await
+        self.borrow_mut().send_message(msg).await
     }
 
     // Receive messages with default options.
     async fn recv_messages(&mut self, link: &Link) -> Result<Vec<Msg>> {
-        (&*self).lock().recv_messages(link).await
+        self.borrow_mut().recv_messages(link).await
     }
 
     // Receive a message with default options.
     async fn recv_message(&mut self, link: &Link) -> Result<Msg> {
-        (&*self).lock().recv_message(link).await
+        self.borrow_mut().recv_message(link).await
+    }
+}
+
+#[cfg(any(feature = "sync-spin", feature = "sync-parking-lot"))]
+mod sync {
+    use super::{
+        Transport,
+        TransportDetails,
+        TransportOptions,
+    };
+    use iota_streams_core::{
+        async_trait,
+        prelude::{
+            Arc,
+            Box,
+            Mutex,
+            Vec,
+        },
+        Result,
+    };
+
+    impl<Tsp: TransportOptions> TransportOptions for Arc<Mutex<Tsp>> {
+        type SendOptions = <Tsp as TransportOptions>::SendOptions;
+        fn get_send_options(&self) -> Self::SendOptions {
+            self.lock().get_send_options()
+        }
+        fn set_send_options(&mut self, opt: Self::SendOptions) {
+            self.lock().set_send_options(opt)
+        }
+
+        type RecvOptions = <Tsp as TransportOptions>::RecvOptions;
+        fn get_recv_options(&self) -> Self::RecvOptions {
+            self.lock().get_recv_options()
+        }
+        fn set_recv_options(&mut self, opt: Self::RecvOptions) {
+            self.lock().set_recv_options(opt)
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl<Link, Tsp: TransportDetails<Link>> TransportDetails<Link> for Arc<Mutex<Tsp>> {
+        type Details = <Tsp as TransportDetails<Link>>::Details;
+        async fn get_link_details(&mut self, link: &Link) -> Result<Self::Details> {
+            self.lock().get_link_details(link).await
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl<Link, Msg, Tsp: Transport<Link, Msg>> Transport<Link, Msg> for Arc<Mutex<Tsp>> {
+        // Send a message.
+        async fn send_message(&mut self, msg: &Msg) -> Result<()> {
+            self.lock().send_message(msg).await
+        }
+
+        // Receive messages with default options.
+        async fn recv_messages(&mut self, link: &Link) -> Result<Vec<Msg>> {
+            self.lock().recv_messages(link).await
+        }
+
+        // Receive a message with default options.
+        async fn recv_message(&mut self, link: &Link) -> Result<Msg> {
+            self.lock().recv_message(link).await
+        }
     }
 }
 

--- a/iota-streams-core/Cargo.toml
+++ b/iota-streams-core/Cargo.toml
@@ -11,9 +11,10 @@ description = "A rust implementation of the IOTA Streams core utils"
 [features]
 default = ["std"]
 # enable std
-std = ["rand/std", "digest/std", "hex/std", "parking_lot"]
-no-std = ["spin"]
+std = ["rand/std", "digest/std", "hex/std"]
 err-location-log = []
+sync-spin = ["spin"]
+sync-parking-lot = ["parking_lot"]
 
 [lib]
 name = "iota_streams_core"
@@ -28,7 +29,7 @@ hashbrown = { version = "0.11.2", default-features = false, optional = false, fe
 hex = { version = "0.4", default-features = false, optional = false, features = ["alloc"] }
 anyhow = { version = "1.0.34", default-features = false, optional = false }
 async-trait = { version = "0.1", optional = false }
-parking_lot = {version = "0.11.2", optional = true }
+parking_lot = { version = "0.11.2", optional = true }
 spin = { version = "0.9.2", default-features = false, features = ["mutex", "spin_mutex"], optional = true }
 
 # thiserror = { version = "1.0.22", default-features = false, optional = false }

--- a/iota-streams-core/src/prelude.rs
+++ b/iota-streams-core/src/prelude.rs
@@ -4,6 +4,10 @@ pub use alloc::{
         self,
         Box,
     },
+    cell::{
+        self,
+        RefCell,
+    },
     format,
     rc::{
         self,
@@ -30,6 +34,10 @@ pub use std::{
         self,
         Box,
     },
+    cell::{
+        self,
+        RefCell,
+    },
     format,
     rc::{
         self,
@@ -50,17 +58,17 @@ pub use std::{
     },
 };
 
-#[cfg(all(feature = "no-std", not(feature = "std")))]
-pub use spin::{
-    Mutex,
-    MutexGuard,
-};
+// Arc<Mutex<Transport>> blanket impl is provided only behind the "sync-spin" or "sync-parking-lot" features,
+//  as a convenience for users that want to share a transport through several user instances.
+// We provide 2 flavours of Mutex: `parking_lot` and `spin`:
+// - `sync-parking-lot` feature enables `parking_lot::Mutex` Mutex (requires `std`)
+// - `sync-spin` feature enables `spin::Mutex` (supports no-std)
+// If both features are provided, `parking_lot` is used.
+#[cfg(all(feature = "sync-spin", not(feature = "sync-parking-lot")))]
+pub use spin::Mutex;
 
-#[cfg(feature = "std")]
-pub use parking_lot::{
-    Mutex,
-    MutexGuard,
-};
+#[cfg(feature = "sync-parking-lot")]
+pub use parking_lot::Mutex;
 
 pub use hashbrown::{
     hash_map,


### PR DESCRIPTION
# Description of change

Removed all uses of synchronization primitives throughout the library. 

I had a suspicion that all those mutexes were not warranted, as no part of Streams runs concurrently at all (we could say almost "by nature"). We provide an `async` API because we do I/O (a quite slow one actually), and we need to give our users the possibility of multitasking asynchronously while waiting for the Tangle to answer. However, unlike a server that needs to handle many concurrent requests, Streams does not share any data between threads (mainly because it only runs in one thread). 

However, we do have to acknowledge the (remote) possibility that a user wants to use the same transport in multiple threads concurrently; because it would be impossible to implement transport for `Arc<Mutex<Tangle::Client>>` or `Arc<Mutex<BucketTransport>>` given the orphan rules of Rust, this PR proposes to still provide them, albeit behind an optional feature (actually 2, `sync-spin`and `sync-parking-lot`). I haven't analysed to which extend these are currently reusable, but still seem like a sensible thing to provide. 

## Type of change

- Refactor that does not breaks compatibility nor adds functionality

## How the change has been tested

- [x] `cargo +nightly fmt`
- [x] `cargo check && cargo check --all-features`
- [x] `touch **/*.rs && cargo clippy && cargo clippy --all-features`
- [x] `cargo doc`
- [x] `(cd bindings/wasm && cargo +nightly fmt)`
- [x] `(cd bindings/wasm && cargo check && cargo check --all-features)`
- [x] `(cd bindings/wasm && touch **/*.rs && cargo clippy && cargo clippy --all-features)`
- ~`(cd bindings/c && cargo +nightly fmt)`~ (fmt of c bindings is not currently maintained, should be applied in a separate PR)
- [x] `(cd bindings/c && cargo check)`
- ~`(cd bindings/c && touch **/*.rs && cargo clippy)`~ (clippy of c bindings is not currently maintained, should be fixed in a separate PR)
- [x] `(cd examples && cargo run)`
- [x] `(cd bindings/wasm && npm ci && npm run build:nodejs && npm run example:nodejs && npm run example:nodets)`
- [x] `(cd bindings/c && make && ./iota_streams_c)`
- ~`cargo test --workspace`~ (tests of DDML are not maintained, should be fixed in a separate PR)
- [x] `cargo test --workspace --doc --all-features`

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
