### PR TITLE
[V2.0] Track Permissions Through Topics

### DIFF
--- a/lets/src/id/permission.rs
+++ b/lets/src/id/permission.rs
@@ -120,9 +120,9 @@ impl<Identifier> Permissioned<Identifier> {
     }
 }
 
-impl Permissioned<&Identifier> {
-    pub fn take(self) -> Permissioned<Identifier> {
-        match self {
+impl From<Permissioned<&Identifier>> for Permissioned<Identifier> {
+    fn from(perm: Permissioned<&Identifier>) -> Self {
+        match perm {
             Permissioned::Read(id) => Permissioned::Read(id.clone()),
             Permissioned::ReadWrite(id, duration) => Permissioned::ReadWrite(id.clone(), duration),
             Permissioned::Admin(id) => Permissioned::Admin(id.clone()),

--- a/lets/src/id/permission.rs
+++ b/lets/src/id/permission.rs
@@ -120,11 +120,11 @@ impl<Identifier> Permissioned<Identifier> {
     }
 }
 
-impl Permissioned<&Identifier>{
+impl Permissioned<&Identifier> {
     pub fn take(self) -> Permissioned<Identifier> {
         match self {
             Permissioned::Read(id) => Permissioned::Read(id.clone()),
-            Permissioned::ReadWrite(id, duration) => Permissioned::ReadWrite(id.clone(), duration.clone()),
+            Permissioned::ReadWrite(id, duration) => Permissioned::ReadWrite(id.clone(), duration),
             Permissioned::Admin(id) => Permissioned::Admin(id.clone()),
         }
     }
@@ -237,9 +237,9 @@ impl Mask<&Permissioned<&Identifier>> for sizeof::Context {
 }
 
 impl<OS, F> Mask<&Permissioned<&Identifier>> for wrap::Context<OS, F>
-    where
-        F: PRP,
-        OS: io::OStream,
+where
+    F: PRP,
+    OS: io::OStream,
 {
     fn mask(&mut self, permission: &Permissioned<&Identifier>) -> Result<&mut Self> {
         self.mask(&permission.take())

--- a/lets/src/id/permission.rs
+++ b/lets/src/id/permission.rs
@@ -153,23 +153,7 @@ where
 
 impl Mask<&Permissioned<Identifier>> for sizeof::Context {
     fn mask(&mut self, permission: &Permissioned<Identifier>) -> Result<&mut Self> {
-        match permission {
-            Permissioned::Read(identifier) => {
-                let oneof = Uint8::new(0);
-                self.mask(oneof)?.mask(identifier)?;
-                Ok(self)
-            }
-            Permissioned::ReadWrite(identifier, duration) => {
-                let oneof = Uint8::new(1);
-                self.mask(oneof)?.mask(duration)?.mask(identifier)?;
-                Ok(self)
-            }
-            Permissioned::Admin(identifier) => {
-                let oneof = Uint8::new(2);
-                self.mask(oneof)?.mask(identifier)?;
-                Ok(self)
-            }
-        }
+        self.mask(&permission.as_ref())
     }
 }
 
@@ -179,23 +163,7 @@ where
     OS: io::OStream,
 {
     fn mask(&mut self, permission: &Permissioned<Identifier>) -> Result<&mut Self> {
-        match permission {
-            Permissioned::Read(identifier) => {
-                let oneof = Uint8::new(0);
-                self.mask(oneof)?.mask(identifier)?;
-                Ok(self)
-            }
-            Permissioned::ReadWrite(identifier, duration) => {
-                let oneof = Uint8::new(1);
-                self.mask(oneof)?.mask(duration)?.mask(identifier)?;
-                Ok(self)
-            }
-            Permissioned::Admin(identifier) => {
-                let oneof = Uint8::new(2);
-                self.mask(oneof)?.mask(identifier)?;
-                Ok(self)
-            }
-        }
+        self.mask(&permission.as_ref())
     }
 }
 
@@ -232,7 +200,23 @@ where
 
 impl Mask<&Permissioned<&Identifier>> for sizeof::Context {
     fn mask(&mut self, permission: &Permissioned<&Identifier>) -> Result<&mut Self> {
-        self.mask(&permission.take())
+        match permission {
+            Permissioned::Read(identifier) => {
+                let oneof = Uint8::new(0);
+                self.mask(oneof)?.mask(*identifier)?;
+                Ok(self)
+            }
+            Permissioned::ReadWrite(identifier, duration) => {
+                let oneof = Uint8::new(1);
+                self.mask(oneof)?.mask(duration)?.mask(*identifier)?;
+                Ok(self)
+            }
+            Permissioned::Admin(identifier) => {
+                let oneof = Uint8::new(2);
+                self.mask(oneof)?.mask(*identifier)?;
+                Ok(self)
+            }
+        }
     }
 }
 
@@ -242,6 +226,22 @@ where
     OS: io::OStream,
 {
     fn mask(&mut self, permission: &Permissioned<&Identifier>) -> Result<&mut Self> {
-        self.mask(&permission.take())
+        match permission {
+            Permissioned::Read(identifier) => {
+                let oneof = Uint8::new(0);
+                self.mask(oneof)?.mask(*identifier)?;
+                Ok(self)
+            }
+            Permissioned::ReadWrite(identifier, duration) => {
+                let oneof = Uint8::new(1);
+                self.mask(oneof)?.mask(duration)?.mask(*identifier)?;
+                Ok(self)
+            }
+            Permissioned::Admin(identifier) => {
+                let oneof = Uint8::new(2);
+                self.mask(oneof)?.mask(*identifier)?;
+                Ok(self)
+            }
+        }
     }
 }

--- a/streams/examples/full-example/scenarios/basic.rs
+++ b/streams/examples/full-example/scenarios/basic.rs
@@ -527,7 +527,6 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
     print_user("Author", &author);
 
     println!("> Subscriber A receives keyload");
-    print_user("Subscriber A", &subscriber_a);
     let next_messages = subscriber_a.fetch_next_messages().await?;
     print_user("Subscriber A", &subscriber_a);
     let last_msg_as_a = next_messages
@@ -545,6 +544,7 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
 
     println!("> Author creates a new branch");
     author.new_branch(BRANCH1, BRANCH2).await?;
+    print_user("Author", &author);
     println!("> Subscriber A receives branch announcement");
     let next_messages = subscriber_a.fetch_next_messages().await?;
     print_user("Subscriber A", &subscriber_a);

--- a/streams/examples/full-example/scenarios/basic.rs
+++ b/streams/examples/full-example/scenarios/basic.rs
@@ -544,7 +544,7 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
             .as_keyload()
             .unwrap()
             .subscribers
-            .contains(&subscriber_a_admin_permission.clone()),
+            .contains(&subscriber_a_admin_permission.take()),
         "Subscriber A expected that they would be included with admin privileges in keyload"
     );
 

--- a/streams/examples/full-example/scenarios/basic.rs
+++ b/streams/examples/full-example/scenarios/basic.rs
@@ -544,7 +544,7 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
             .as_keyload()
             .unwrap()
             .subscribers
-            .contains(&subscriber_a_admin_permission.take()),
+            .contains(&subscriber_a_admin_permission.into()),
         "Subscriber A expected that they would be included with admin privileges in keyload"
     );
 

--- a/streams/examples/full-example/scenarios/basic.rs
+++ b/streams/examples/full-example/scenarios/basic.rs
@@ -565,7 +565,7 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
     println!("> Subscriber A confirming they still have Admin privileges in new branch");
     assert!(
         subscriber_a
-            .permission(BRANCH2)
+            .permission(&BRANCH2.into())
             .expect("Subscriber A should have a permission stored for new branch")
             .is_admin(),
         "Subscriber A expected to still have Admin privileges in new branch"

--- a/streams/examples/full-example/scenarios/basic.rs
+++ b/streams/examples/full-example/scenarios/basic.rs
@@ -544,7 +544,7 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
             .as_keyload()
             .unwrap()
             .subscribers
-            .contains(&subscriber_a_admin_permission.take()),
+            .contains(&subscriber_a_admin_permission.clone()),
         "Subscriber A expected that they would be included with admin privileges in keyload"
     );
 

--- a/streams/examples/full-example/scenarios/basic.rs
+++ b/streams/examples/full-example/scenarios/basic.rs
@@ -21,6 +21,7 @@ const MASKED_PAYLOAD: &[u8] = b"MASKEDPAYLOAD";
 
 const BASE_BRANCH: &str = "BASE_BRANCH";
 const BRANCH1: &str = "BRANCH1";
+const BRANCH2: &str = "BRANCH2";
 
 pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str) -> Result<()> {
     let psk = Psk::from_seed("A pre shared key");
@@ -497,11 +498,11 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
 
     println!("> Subscribers A and B try to send a signed packet");
     // TODO: THIS SHOULD FAIL ONCE PUBLISHERS ARE TRACKED BY BRANCH AND WE CAN "DEMOTE" SUBSCRIBERS
-    let a_signed_packet = subscriber_a
+    let result = subscriber_a
         .send_signed_packet(BRANCH1, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
-        .await?;
-    print_send_result(&a_signed_packet);
+        .await;
     print_user("Subscriber A", &subscriber_a);
+    assert!(result.is_err());
     let result = subscriber_b
         .send_signed_packet(BRANCH1, PUBLIC_PAYLOAD, MASKED_PAYLOAD)
         .await;
@@ -517,6 +518,51 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
     print_user("Subscriber B", &subscriber_b);
     assert_eq!(subscriber_c.sync().await?, 0);
     print_user("Subscriber C", &subscriber_c);
+
+    println!("> Author adds Subscriber A again and grants them Admin privileges");
+    print_user("Author", &author);
+    assert!(author.add_subscriber(subscriber_a_id.clone()));
+    let subscriber_a_admin_permission = Permissioned::Admin(&subscriber_a_id);
+    author.send_keyload(BRANCH1, vec![subscriber_a_admin_permission], vec![]).await?;
+    print_user("Author", &author);
+
+    println!("> Subscriber A receives keyload");
+    print_user("Subscriber A", &subscriber_a);
+    let next_messages = subscriber_a.fetch_next_messages().await?;
+    print_user("Subscriber A", &subscriber_a);
+    let last_msg_as_a = next_messages
+        .last()
+        .expect("Subscriber A has not received the latest keyload");
+    assert!(
+        last_msg_as_a.is_keyload(),
+        "Subscriber A expected the last message to be a keyload message, found {:?} instead",
+        last_msg_as_a.content()
+    );
+    assert!(
+        last_msg_as_a.as_keyload().unwrap().subscribers.contains(&subscriber_a_admin_permission.take()),
+        "Subscriber A expected that they would be included with admin privileges in keyload"
+    );
+
+    println!("> Author creates a new branch");
+    author.new_branch(BRANCH1, BRANCH2).await?;
+    println!("> Subscriber A receives branch announcement");
+    let next_messages = subscriber_a.fetch_next_messages().await?;
+    print_user("Subscriber A", &subscriber_a);
+    let last_msg_as_a = next_messages
+        .last()
+        .expect("Subscriber A has not received the latest branch announcement");
+    assert!(
+        last_msg_as_a.is_branch_announcement(),
+        "Subscriber A expected the last message to be a branch announcement message, found {:?} instead",
+        last_msg_as_a.content()
+    );
+    println!("> Subscriber A confirming they still have Admin privileges in new branch");
+    assert!(
+        subscriber_a.permission(BRANCH2)
+            .expect("Subscriber A should have a permission stored for new branch")
+            .is_admin(),
+        "Subscriber A expected to still have Admin privileges in new branch"
+    );
 
     Ok(())
 }

--- a/streams/examples/full-example/scenarios/basic.rs
+++ b/streams/examples/full-example/scenarios/basic.rs
@@ -523,7 +523,9 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
     print_user("Author", &author);
     assert!(author.add_subscriber(subscriber_a_id.clone()));
     let subscriber_a_admin_permission = Permissioned::Admin(&subscriber_a_id);
-    author.send_keyload(BRANCH1, vec![subscriber_a_admin_permission], vec![]).await?;
+    author
+        .send_keyload(BRANCH1, vec![subscriber_a_admin_permission], vec![])
+        .await?;
     print_user("Author", &author);
 
     println!("> Subscriber A receives keyload");
@@ -538,7 +540,11 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
         last_msg_as_a.content()
     );
     assert!(
-        last_msg_as_a.as_keyload().unwrap().subscribers.contains(&subscriber_a_admin_permission.take()),
+        last_msg_as_a
+            .as_keyload()
+            .unwrap()
+            .subscribers
+            .contains(&subscriber_a_admin_permission.take()),
         "Subscriber A expected that they would be included with admin privileges in keyload"
     );
 
@@ -558,7 +564,8 @@ pub(crate) async fn example<T: GenericTransport>(transport: T, author_seed: &str
     );
     println!("> Subscriber A confirming they still have Admin privileges in new branch");
     assert!(
-        subscriber_a.permission(BRANCH2)
+        subscriber_a
+            .permission(BRANCH2)
             .expect("Subscriber A should have a permission stored for new branch")
             .is_admin(),
         "Subscriber A expected to still have Admin privileges in new branch"

--- a/streams/examples/full-example/scenarios/did.rs
+++ b/streams/examples/full-example/scenarios/did.rs
@@ -132,7 +132,7 @@ pub async fn example(transport: Rc<RefCell<tangle::Client>>) -> Result<()> {
     print_send_result(&last_msg);
     print_user("Author", &author);
 
-    println!("> Subscriber C receives 8 messages:");
+    println!("> Subscriber C receives 9 messages:");
     let messages_as_c = subscriber_c.fetch_next_messages().await?;
     print_user("Subscriber C", &subscriber_c);
     for message in &messages_as_c {
@@ -140,9 +140,9 @@ pub async fn example(transport: Rc<RefCell<tangle::Client>>) -> Result<()> {
         println!("{}", indent(&fill(&format!("{:?}", message.content()), 140), "\t| "));
         println!("\t---");
     }
-    assert_eq!(8, messages_as_c.len());
+    assert_eq!(9, messages_as_c.len());
 
-    println!("> Subscriber B receives 8 messages:");
+    println!("> Subscriber B receives 9 messages:");
     let messages_as_b = subscriber_b.fetch_next_messages().await?;
     print_user("Subscriber B", &subscriber_b);
     for message in &messages_as_c {
@@ -150,9 +150,9 @@ pub async fn example(transport: Rc<RefCell<tangle::Client>>) -> Result<()> {
         println!("{}", indent(&fill(&format!("{:?}", message.content()), 140), "\t| "));
         println!("\t---");
     }
-    assert_eq!(8, messages_as_b.len());
+    assert_eq!(9, messages_as_b.len());
 
-    println!("> Subscriber A receives 6 messages:");
+    println!("> Subscriber A receives 7 messages:");
     let messages_as_a = subscriber_a.fetch_next_messages().await?;
     print_user("Subscriber A", &subscriber_a);
     for message in &messages_as_c {

--- a/streams/src/api/cursor_store.rs
+++ b/streams/src/api/cursor_store.rs
@@ -156,7 +156,7 @@ mod tests {
     use super::CursorStore;
     use alloc::string::ToString;
     use lets::{
-        id::{Ed25519, Identity},
+        id::{Ed25519, Identity, PermissionDuration, Permissioned},
         message::Topic,
     };
 
@@ -164,18 +164,19 @@ mod tests {
     fn branch_store_can_remove_a_cursor_from_all_branches_at_once() {
         let mut branch_store = CursorStore::new();
         let identifier = Identity::Ed25519(Ed25519::from_seed("identifier 1")).to_identifier();
+        let permission = Permissioned::ReadWrite(identifier.clone(), PermissionDuration::Perpetual);
         let topic_1 = Topic::new("topic 1".to_string());
         let topic_2 = Topic::new("topic 2".to_string());
 
         branch_store.new_branch(topic_1.clone());
         branch_store.new_branch(topic_2.clone());
 
-        branch_store.insert_cursor(&topic_1, identifier.clone(), 10);
-        branch_store.insert_cursor(&topic_2, identifier.clone(), 20);
+        branch_store.insert_cursor(&topic_1, permission.clone(), 10);
+        branch_store.insert_cursor(&topic_2, permission.clone(), 20);
 
         branch_store.remove(&identifier);
 
-        assert!(!branch_store.is_cursor_tracked(&topic_1, &identifier));
-        assert!(!branch_store.is_cursor_tracked(&topic_2, &identifier));
+        assert!(branch_store.get_cursor(&topic_1, &identifier).is_none());
+        assert!(branch_store.get_cursor(&topic_2, &identifier).is_none());
     }
 }

--- a/streams/src/api/messages.rs
+++ b/streams/src/api/messages.rs
@@ -17,11 +17,10 @@ use hashbrown::HashMap;
 // Streams
 use lets::{
     address::{Address, MsgId},
-    id::Identifier,
+    id::{Identifier, Permissioned},
     message::{Topic, TransportMessage, HDF},
     transport::Transport,
 };
-use lets::id::Permissioned;
 
 // Local
 use crate::api::{

--- a/streams/src/api/user.rs
+++ b/streams/src/api/user.rs
@@ -202,7 +202,7 @@ impl<T> User<T> {
     }
 
     pub fn remove_subscriber(&mut self, id: &Identifier) -> bool {
-        self.state.cursor_store.remove(id) | self.state.exchange_keys.remove(id).is_some()
+        self.state.exchange_keys.remove(id).is_some()
     }
 
     pub fn add_psk(&mut self, psk: Psk) -> bool {
@@ -444,7 +444,8 @@ impl<T> User<T> {
         for (_, perm, cursor) in stored_subscribers {
             if subscribers
                 .iter()
-                .find(|p| p.identifier() == perm.identifier()).is_none()
+                .find(|p| perm.identifier() == author_identifier || p.identifier() == perm.identifier())
+                .is_none()
             {
                 self
                     .state

--- a/streams/src/api/user.rs
+++ b/streams/src/api/user.rs
@@ -988,7 +988,7 @@ where
             if self.should_store_cursor(&topic, subscriber) {
                 self.state
                     .cursor_store
-                    .insert_cursor(&topic, subscriber.take(), INIT_MESSAGE_NUM);
+                    .insert_cursor(&topic, subscriber.into(), INIT_MESSAGE_NUM);
             }
         }
         self.state


### PR DESCRIPTION
# Description of change
Currently the only place we use `Permissioned` is when we are doing checks on `Keyload` messages, but those permissions are not retained in store anywhere, as our cursor store only uses the Identifier. To allow for that permission retention we need to change `CursorStore` to map by `Permissioned<Identifier>` instead of just `Identifier`. This brings a host of other trickling changes along with it. 

For example, a `User` will be able to check their permissions on a topic before they attempt to send messages, failing if they are registered as `Read` by a topic administrator. Additionally administrative privileges can be properly assigned and forwarded through the topics. 


## Type of change
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested
New section added to end of examples to have `Author` re-subscribe `SubscriberA` and grant them Admin privileges, confirming that they carry forward into new branches. 
- All previous examples complete
- All previous tests complete 

